### PR TITLE
🔒 Security Fix: Add missing noreferrer on external link

### DIFF
--- a/src/pages/offers/expired.astro
+++ b/src/pages/offers/expired.astro
@@ -147,7 +147,7 @@ const pageDescription = campaignTitle
             
             <div class="contact-method">
               <h3>WhatsApp</h3>
-              <a href="https://wa.me/919999999999" target="_blank" rel="noopener">
+              <a href="https://wa.me/919999999999" target="_blank" rel="noopener noreferrer">
                 Chat on WhatsApp
               </a>
             </div>


### PR DESCRIPTION
🎯 **What:** Added `noreferrer` to the `rel` attribute of an external WhatsApp link (`target="_blank"`) in `src/pages/offers/expired.astro`.

⚠️ **Risk:** Without `noreferrer`, the external site (WhatsApp in this case) would receive the URL of the referring page. While not always a severe vulnerability, it's a privacy concern. Additionally, when combined with `target="_blank"`, omitting `noopener` (which was already there) or `noreferrer` can sometimes be exploited in older browsers for "tabnabbing", where the newly opened window can change the `window.opener.location` of the original window. Adding `noreferrer` is a standard best practice to prevent the leakage of referring page details.

🛡️ **Solution:** Updated the link to include `rel="noopener noreferrer"`. This prevents the referring information from being passed to the target website, ensuring a secure and private external link interaction.

---
*PR created automatically by Jules for task [15824688378807296518](https://jules.google.com/task/15824688378807296518) started by @theWhiteWulfy*