### PR TITLE
🧹 [Code Health] Refactor duplicated adjacent post logic into getAdjacentPosts utility

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -14,3 +14,18 @@ export function readingTime(html: string) {
   const readingTimeMinutes = (wordCount / 180 + 1).toFixed(); // 180 words per minute
   return `${readingTimeMinutes} min read`;
 }
+
+export function getAdjacentPosts<T extends { slug: string }>(currentSlug: string | undefined, posts: T[]) {
+  let postIndex = -1;
+  for (let i = 0; i < posts.length; i++) {
+    if (posts[i].slug === currentSlug) {
+      postIndex = i;
+      break;
+    }
+  }
+
+  return {
+    nextPost: postIndex !== -1 ? posts[postIndex + 1] : undefined,
+    prevPost: postIndex !== -1 ? posts[postIndex - 1] : undefined,
+  };
+}

--- a/src/pages/articles/[...slug].astro
+++ b/src/pages/articles/[...slug].astro
@@ -4,6 +4,7 @@ import Layout from "@layouts/Layout.astro";
 import PostNavigation from "@components/PostNavigation.astro";
 import style from "@styles/document.module.css";
 import { slugify } from '@lib/slugify.mjs';
+import { getAdjacentPosts } from '@lib/utils';
 import Link from "@components/Link.astro";
 import TableOfContents from "@components/TableOfContents.astro";
 import AstroImage from "@components/AstroImage.astro";
@@ -24,28 +25,7 @@ type Props = CollectionEntry<"articles">;
 
 const posts = await getCollection("articles");
 
-function getNextPost() {
-  let postIndex;
-  for (const post of posts) {
-    if (post.slug === Astro.params.slug) {
-      postIndex = posts.indexOf(post);
-      return posts[postIndex + 1];
-    }
-  }
-}
-
-function getPrevPost() {
-  let postIndex;
-  for (const post of posts) {
-    if (post.slug === Astro.params.slug) {
-      postIndex = posts.indexOf(post);
-      return posts[postIndex - 1];
-    }
-  }
-}
-
-const nextPost = getNextPost();
-const prevPost = getPrevPost();
+const { nextPost, prevPost } = getAdjacentPosts(Astro.params.slug, posts);
 
 const post = Astro.props;
 const { Content, headings, remarkPluginFrontmatter } = await post.render();

--- a/src/pages/bibliophilediaries/[...slug].astro
+++ b/src/pages/bibliophilediaries/[...slug].astro
@@ -4,6 +4,7 @@ import Layout from "@layouts/Layout.astro";
 import PostNavigation from "@components/PostNavigation.astro";
 import style from "@styles/document.module.css";
 import { slugify } from '@lib/slugify.mjs';
+import { getAdjacentPosts } from '@lib/utils';
 import Link from "@components/Link.astro";
 import TableOfContents from "@components/TableOfContents.astro";
 import AstroImage from "@components/AstroImage.astro";
@@ -24,28 +25,7 @@ type Props = CollectionEntry<"bibliophilediaries">;
 
 const posts = await getCollection("bibliophilediaries");
 
-function getNextPost() {
-  let postIndex;
-  for (const post of posts) {
-    if (post.slug === Astro.params.slug) {
-      postIndex = posts.indexOf(post);
-      return posts[postIndex + 1];
-    }
-  }
-}
-
-function getPrevPost() {
-  let postIndex;
-  for (const post of posts) {
-    if (post.slug === Astro.params.slug) {
-      postIndex = posts.indexOf(post);
-      return posts[postIndex - 1];
-    }
-  }
-}
-
-const nextPost = getNextPost();
-const prevPost = getPrevPost();
+const { nextPost, prevPost } = getAdjacentPosts(Astro.params.slug, posts);
 
 const post = Astro.props;
 const { Content, headings, remarkPluginFrontmatter } = await post.render();

--- a/src/pages/faqs/[...slug].astro
+++ b/src/pages/faqs/[...slug].astro
@@ -4,6 +4,7 @@ import Layout from "@layouts/Layout.astro";
 import { slugify } from '@lib/slugify.mjs';
 import PostNavigation from "@components/PostNavigation.astro";
 import style from "@styles/document.module.css";
+import { getAdjacentPosts } from '@lib/utils';
 import Link from "@components/Link.astro";
 import TableOfContents from "@components/TableOfContents.astro";
 import AstroImage from "@components/AstroImage.astro";
@@ -25,28 +26,7 @@ type Props = CollectionEntry<"faqs">;
 
 const posts = await getCollection("faqs");
 
-function getNextPost() {
-  let postIndex;
-  for (const post of posts) {
-    if (post.slug === Astro.params.slug) {
-      postIndex = posts.indexOf(post);
-      return posts[postIndex + 1];
-    }
-  }
-}
-
-function getPrevPost() {
-  let postIndex;
-  for (const post of posts) {
-    if (post.slug === Astro.params.slug) {
-      postIndex = posts.indexOf(post);
-      return posts[postIndex - 1];
-    }
-  }
-}
-
-const nextPost = getNextPost();
-const prevPost = getPrevPost();
+const { nextPost, prevPost } = getAdjacentPosts(Astro.params.slug, posts);
 
 const post = Astro.props;
 const { Content, headings, remarkPluginFrontmatter } = await post.render();

--- a/src/pages/notes/[...slug].astro
+++ b/src/pages/notes/[...slug].astro
@@ -4,6 +4,7 @@ import Layout from "@layouts/Layout.astro";
 import PostNavigation from "@components/PostNavigation.astro";
 import style from "@styles/document.module.css";
 import { slugify } from '@lib/slugify.mjs';
+import { getAdjacentPosts } from '@lib/utils';
 import Link from "@components/Link.astro";
 import TableOfContents from "@components/TableOfContents.astro";
 import AstroImage from "@components/AstroImage.astro";
@@ -24,28 +25,7 @@ type Props = CollectionEntry<"notes">;
 
 const posts = await getCollection("notes");
 
-function getNextPost() {
-  let postIndex;
-  for (const post of posts) {
-    if (post.slug === Astro.params.slug) {
-      postIndex = posts.indexOf(post);
-      return posts[postIndex + 1];
-    }
-  }
-}
-
-function getPrevPost() {
-  let postIndex;
-  for (const post of posts) {
-    if (post.slug === Astro.params.slug) {
-      postIndex = posts.indexOf(post);
-      return posts[postIndex - 1];
-    }
-  }
-}
-
-const nextPost = getNextPost();
-const prevPost = getPrevPost();
+const { nextPost, prevPost } = getAdjacentPosts(Astro.params.slug, posts);
 
 const post = Astro.props;
 const { Content, headings, remarkPluginFrontmatter } = await post.render();

--- a/src/pages/saasguide/[...slug].astro
+++ b/src/pages/saasguide/[...slug].astro
@@ -4,6 +4,7 @@ import Layout from "@layouts/Layout.astro";
 import PostNavigation from "@components/PostNavigation.astro";
 import style from "@styles/document.module.css";
 import { slugify } from '@lib/slugify.mjs';
+import { getAdjacentPosts } from '@lib/utils';
 import Link from "@components/Link.astro";
 import TableOfContents from "@components/TableOfContents.astro";
 import AstroImage from "@components/AstroImage.astro";
@@ -25,28 +26,7 @@ type Props = CollectionEntry<"saasguide">;
 
 const posts = await getCollection("saasguide");
 
-function getNextPost() {
-  let postIndex;
-  for (const post of posts) {
-    if (post.slug === Astro.params.slug) {
-      postIndex = posts.indexOf(post);
-      return posts[postIndex + 1];
-    }
-  }
-}
-
-function getPrevPost() {
-  let postIndex;
-  for (const post of posts) {
-    if (post.slug === Astro.params.slug) {
-      postIndex = posts.indexOf(post);
-      return posts[postIndex - 1];
-    }
-  }
-}
-
-const nextPost = getNextPost();
-const prevPost = getPrevPost();
+const { nextPost, prevPost } = getAdjacentPosts(Astro.params.slug, posts);
 
 const post = Astro.props;
 const { Content, headings, remarkPluginFrontmatter } = await post.render();

--- a/src/pages/works/[...slug].astro
+++ b/src/pages/works/[...slug].astro
@@ -4,6 +4,7 @@ import Layout from "@layouts/Layout.astro";
 import PostNavigation from "@components/PostNavigation.astro";
 import style from "@styles/document.module.css";
 import { slugify } from '@lib/slugify.mjs';
+import { getAdjacentPosts } from '@lib/utils';
 import Link from "@components/Link.astro";
 import TableOfContents from "@components/TableOfContents.astro";
 import AstroImage from "@components/AstroImage.astro";
@@ -24,28 +25,7 @@ type Props = CollectionEntry<"works">;
 
 const posts = await getCollection("works");
 
-function getNextPost() {
-  let postIndex;
-  for (const post of posts) {
-    if (post.slug === Astro.params.slug) {
-      postIndex = posts.indexOf(post);
-      return posts[postIndex + 1];
-    }
-  }
-}
-
-function getPrevPost() {
-  let postIndex;
-  for (const post of posts) {
-    if (post.slug === Astro.params.slug) {
-      postIndex = posts.indexOf(post);
-      return posts[postIndex - 1];
-    }
-  }
-}
-
-const nextPost = getNextPost();
-const prevPost = getPrevPost();
+const { nextPost, prevPost } = getAdjacentPosts(Astro.params.slug, posts);
 
 const post = Astro.props;
 const { Content, headings, remarkPluginFrontmatter } = await post.render();


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Extracted the duplicated `getNextPost` and `getPrevPost` functions from six different `[...slug].astro` collection pages into a single, generic `getAdjacentPosts` utility function in `src/lib/utils.ts`.

💡 **Why:** How this improves maintainability
The logic for finding the adjacent previous and next posts was identical across six different files. Keeping this logic duplicated leads to higher maintenance costs and a risk of divergence. This refactoring standardizes the behavior into a single source of truth. Additionally, the new utility uses an $O(N)$ lookup loop instead of calling `indexOf` inside a loop, slightly improving algorithmic efficiency.

✅ **Verification:** How you confirmed the change is safe
Ran `npm run build` to verify that the TypeScript types and the Astro compiler still checked the modified files properly. Also carefully confirmed that the logic remains unchanged (returning `undefined` for boundary cases).

✨ **Result:** The improvement achieved
A cleaner codebase with less boilerplate code in the collection pages and a newly available, strongly-typed utility function.

---
*PR created automatically by Jules for task [8381209886287938698](https://jules.google.com/task/8381209886287938698) started by @theWhiteWulfy*