### PR TITLE
🧹 [Code Health] Extract duplicated post navigation logic into utility function

### DIFF
--- a/fix_conflict.py
+++ b/fix_conflict.py
@@ -1,0 +1,20 @@
+import re
+
+with open('src/lib/utils.ts', 'r') as f:
+    content = f.read()
+
+content = re.sub(
+    r'<<<<<<< HEAD\nexport function getAdjacentPosts\(posts: any\[\], currentSlug: string \| undefined\) \{\n  const postIndex = posts.findIndex\(\(post\) => post.slug === currentSlug\);\n\n  if \(postIndex === -1\) \{\n    return \{ nextPost: undefined, prevPost: undefined \};\n  \}\n\n=======\nexport function getAdjacentPosts<T extends \{ slug: string \}>\(\n  posts: T\[\],\n  currentSlug: string \| undefined\n\) \{\n  const postIndex = posts.findIndex\(\(post\) => post.slug === currentSlug\);\n  if \(postIndex === -1\) \{\n    return \{ nextPost: undefined, prevPost: undefined \};\n  \}\n>>>>>>> origin\/main',
+    r'''export function getAdjacentPosts<T extends { slug: string }>(
+  posts: T[],
+  currentSlug: string | undefined
+) {
+  const postIndex = posts.findIndex((post) => post.slug === currentSlug);
+  if (postIndex === -1) {
+    return { nextPost: undefined, prevPost: undefined };
+  }''',
+    content
+)
+
+with open('src/lib/utils.ts', 'w') as f:
+    f.write(content)

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
             "dependencies": {
                 "@astrojs/cloudflare": "^11.0.1",
                 "@fontsource/prompt": "^5.0.14",
-                "@fontsource/zilla-slab": "^5.0.13"
+                "@fontsource/zilla-slab": "^5.0.13",
+                "sanitize-html": "^2.17.4"
             },
             "devDependencies": {
                 "@astrojs/check": "^0.7.0",
@@ -19,6 +20,7 @@
                 "@astrojs/sitemap": "^3.1.5",
                 "@cloudflare/workers-types": "^4.20240729.0",
                 "@playform/compress": "^0.0.13",
+                "@types/sanitize-html": "^2.16.1",
                 "astro": "^4.15.12",
                 "cssnano": "^7.0.2",
                 "dayjs": "^1.11.11",
@@ -5806,6 +5808,16 @@
             "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
             "dev": true
         },
+        "node_modules/@types/sanitize-html": {
+            "version": "2.16.1",
+            "resolved": "https://registry.npmjs.org/@types/sanitize-html/-/sanitize-html-2.16.1.tgz",
+            "integrity": "sha512-n9wjs8bCOTyN/ynwD8s/nTcTreIHB1vf31vhLMGqUPNHaweKC4/fAl4Dj+hUlCTKYgm4P3k83fmiFfzkZ6sgMA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "htmlparser2": "^10.1"
+            }
+        },
         "node_modules/@types/sax": {
             "version": "1.2.7",
             "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
@@ -6774,9 +6786,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001727",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001727.tgz",
-            "integrity": "sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q==",
+            "version": "1.0.30001797",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001797.tgz",
+            "integrity": "sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -7553,8 +7565,7 @@
         "node_modules/dayjs": {
             "version": "1.11.11",
             "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.11.tgz",
-            "integrity": "sha512-okzr3f11N6WuqYtZSvm+F776mB41wRZMhKP+hc34YdW+KmtYYK9iqvHSwo2k9FEH3fhGXvOPV6yz2IcSrfRUDg==",
-            "dev": true
+            "integrity": "sha512-okzr3f11N6WuqYtZSvm+F776mB41wRZMhKP+hc34YdW+KmtYYK9iqvHSwo2k9FEH3fhGXvOPV6yz2IcSrfRUDg=="
         },
         "node_modules/debug": {
             "version": "4.3.7",
@@ -7588,7 +7599,6 @@
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
             "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -7705,7 +7715,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
             "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-            "dev": true,
             "dependencies": {
                 "domelementtype": "^2.3.0",
                 "domhandler": "^5.0.2",
@@ -7719,7 +7728,6 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
             "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -7731,7 +7739,6 @@
             "version": "5.0.3",
             "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
             "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-            "dev": true,
             "dependencies": {
                 "domelementtype": "^2.3.0"
             },
@@ -7743,10 +7750,10 @@
             }
         },
         "node_modules/domutils": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
-            "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
-            "dev": true,
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+            "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+            "license": "BSD-2-Clause",
             "dependencies": {
                 "dom-serializer": "^2.0.0",
                 "domelementtype": "^2.3.0",
@@ -8993,6 +9000,37 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
+        "node_modules/htmlparser2": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+            "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+            "funding": [
+                "https://github.com/fb55/htmlparser2?sponsor=1",
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fb55"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.3",
+                "domutils": "^3.2.2",
+                "entities": "^7.0.1"
+            }
+        },
+        "node_modules/htmlparser2/node_modules/entities": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+            "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
         "node_modules/http-cache-semantics": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
@@ -9403,6 +9441,15 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/is-plain-object": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+            "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/is-reference": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.2.tgz",
@@ -9736,6 +9783,15 @@
             "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/launder": {
+            "version": "1.7.1",
+            "resolved": "https://registry.npmjs.org/launder/-/launder-1.7.1.tgz",
+            "integrity": "sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw==",
+            "license": "MIT",
+            "dependencies": {
+                "dayjs": "^1.11.7"
             }
         },
         "node_modules/leven": {
@@ -11621,6 +11677,12 @@
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
             }
+        },
+        "node_modules/parse-srcset": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+            "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==",
+            "license": "MIT"
         },
         "node_modules/parse5": {
             "version": "7.1.2",
@@ -14147,6 +14209,21 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/sanitize-html": {
+            "version": "2.17.4",
+            "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.4.tgz",
+            "integrity": "sha512-2HW7v2ol/uAM7sX4hbD8Z59OGWmAPrvjL8E71UWlBcj6m+kcF6ilQBLny+cIgY214QJeJT5tQuxKKqX0SQqjGQ==",
+            "license": "MIT",
+            "dependencies": {
+                "deepmerge": "^4.2.2",
+                "escape-string-regexp": "^4.0.0",
+                "htmlparser2": "^10.1.0",
+                "is-plain-object": "^5.0.0",
+                "launder": "^1.7.1",
+                "parse-srcset": "^1.0.2",
+                "postcss": "^8.3.11"
             }
         },
         "node_modules/sass-formatter": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "dependencies": {
         "@astrojs/cloudflare": "^11.0.1",
         "@fontsource/prompt": "^5.0.14",
-        "@fontsource/zilla-slab": "^5.0.13"
+        "@fontsource/zilla-slab": "^5.0.13",
+        "sanitize-html": "^2.17.4"
     },
     "devDependencies": {
         "@astrojs/check": "^0.7.0",
@@ -28,6 +29,7 @@
         "@astrojs/sitemap": "^3.1.5",
         "@cloudflare/workers-types": "^4.20240729.0",
         "@playform/compress": "^0.0.13",
+        "@types/sanitize-html": "^2.16.1",
         "astro": "^4.15.12",
         "cssnano": "^7.0.2",
         "dayjs": "^1.11.11",

--- a/src/components/CampaignCTA.astro
+++ b/src/components/CampaignCTA.astro
@@ -231,7 +231,7 @@ const formId = `campaign-form-${campaignSlug}`;
             <p class="privacy-note">
               <span class="privacy-icon">🔒</span>
               Your information is secure and will never be shared.
-              <a href="/terms/" target="_blank">Privacy Policy</a>
+              <a href="/terms/" target="_blank" rel="noopener noreferrer">Privacy Policy</a>
             </p>
 
             {

--- a/src/lib/api/validation.ts
+++ b/src/lib/api/validation.ts
@@ -1,6 +1,7 @@
 /**
  * Form validation and sanitization utilities
  */
+import sanitizeHtml from 'sanitize-html';
 
 // Email validation regex pattern
 const EMAIL_REGEX = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
@@ -36,18 +37,10 @@ export function sanitizeInput(input: string): string {
     return '';
   }
   
-  return input
-    .trim()
-    // Remove HTML tags
-    .replace(/<[^>]*>/g, '')
-    // Remove script content
-    .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
-    // Remove javascript: protocol
-    .replace(/javascript:/gi, '')
-    // Remove on* event handlers
-    .replace(/\s*on\w+\s*=\s*["'][^"']*["']/gi, '')
-    // Limit length to prevent abuse
-    .substring(0, 500);
+  return sanitizeHtml(input.trim(), {
+    allowedTags: [],
+    allowedAttributes: {}
+  }).substring(0, 500);
 }
 
 /**

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -15,13 +15,14 @@ export function readingTime(html: string) {
   return `${readingTimeMinutes} min read`;
 }
 
-export function getAdjacentPosts(posts: any[], currentSlug: string | undefined) {
+export function getAdjacentPosts<T extends { slug: string }>(
+  posts: T[],
+  currentSlug: string | undefined
+) {
   const postIndex = posts.findIndex((post) => post.slug === currentSlug);
-
   if (postIndex === -1) {
     return { nextPost: undefined, prevPost: undefined };
   }
-
   return {
     nextPost: posts[postIndex + 1],
     prevPost: posts[postIndex - 1],

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -14,3 +14,16 @@ export function readingTime(html: string) {
   const readingTimeMinutes = (wordCount / 180 + 1).toFixed(); // 180 words per minute
   return `${readingTimeMinutes} min read`;
 }
+
+export function getAdjacentPosts(posts: any[], currentSlug: string | undefined) {
+  const postIndex = posts.findIndex((post) => post.slug === currentSlug);
+
+  if (postIndex === -1) {
+    return { nextPost: undefined, prevPost: undefined };
+  }
+
+  return {
+    nextPost: posts[postIndex + 1],
+    prevPost: posts[postIndex - 1],
+  };
+}

--- a/src/pages/articles/[...slug].astro
+++ b/src/pages/articles/[...slug].astro
@@ -9,6 +9,7 @@ import TableOfContents from "@components/TableOfContents.astro";
 import AstroImage from "@components/AstroImage.astro";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
+import { getAdjacentPosts } from "@lib/utils";
 dayjs.extend(utc);
 
 export async function getStaticPaths() {
@@ -24,28 +25,7 @@ type Props = CollectionEntry<"articles">;
 
 const posts = await getCollection("articles");
 
-function getNextPost() {
-  let postIndex;
-  for (const post of posts) {
-    if (post.slug === Astro.params.slug) {
-      postIndex = posts.indexOf(post);
-      return posts[postIndex + 1];
-    }
-  }
-}
-
-function getPrevPost() {
-  let postIndex;
-  for (const post of posts) {
-    if (post.slug === Astro.params.slug) {
-      postIndex = posts.indexOf(post);
-      return posts[postIndex - 1];
-    }
-  }
-}
-
-const nextPost = getNextPost();
-const prevPost = getPrevPost();
+const { nextPost, prevPost } = getAdjacentPosts(posts, Astro.params.slug);
 
 const post = Astro.props;
 const { Content, headings, remarkPluginFrontmatter } = await post.render();

--- a/src/pages/bibliophilediaries/[...slug].astro
+++ b/src/pages/bibliophilediaries/[...slug].astro
@@ -9,6 +9,7 @@ import TableOfContents from "@components/TableOfContents.astro";
 import AstroImage from "@components/AstroImage.astro";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
+import { getAdjacentPosts } from "@lib/utils";
 dayjs.extend(utc);
 
 export async function getStaticPaths() {
@@ -24,28 +25,7 @@ type Props = CollectionEntry<"bibliophilediaries">;
 
 const posts = await getCollection("bibliophilediaries");
 
-function getNextPost() {
-  let postIndex;
-  for (const post of posts) {
-    if (post.slug === Astro.params.slug) {
-      postIndex = posts.indexOf(post);
-      return posts[postIndex + 1];
-    }
-  }
-}
-
-function getPrevPost() {
-  let postIndex;
-  for (const post of posts) {
-    if (post.slug === Astro.params.slug) {
-      postIndex = posts.indexOf(post);
-      return posts[postIndex - 1];
-    }
-  }
-}
-
-const nextPost = getNextPost();
-const prevPost = getPrevPost();
+const { nextPost, prevPost } = getAdjacentPosts(posts, Astro.params.slug);
 
 const post = Astro.props;
 const { Content, headings, remarkPluginFrontmatter } = await post.render();

--- a/src/pages/faqs/[...slug].astro
+++ b/src/pages/faqs/[...slug].astro
@@ -10,6 +10,7 @@ import AstroImage from "@components/AstroImage.astro";
 import type { FAQData } from "@lib/schema-generators";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
+import { getAdjacentPosts } from "@lib/utils";
 dayjs.extend(utc);
 
 export async function getStaticPaths() {
@@ -25,28 +26,7 @@ type Props = CollectionEntry<"faqs">;
 
 const posts = await getCollection("faqs");
 
-function getNextPost() {
-  let postIndex;
-  for (const post of posts) {
-    if (post.slug === Astro.params.slug) {
-      postIndex = posts.indexOf(post);
-      return posts[postIndex + 1];
-    }
-  }
-}
-
-function getPrevPost() {
-  let postIndex;
-  for (const post of posts) {
-    if (post.slug === Astro.params.slug) {
-      postIndex = posts.indexOf(post);
-      return posts[postIndex - 1];
-    }
-  }
-}
-
-const nextPost = getNextPost();
-const prevPost = getPrevPost();
+const { nextPost, prevPost } = getAdjacentPosts(posts, Astro.params.slug);
 
 const post = Astro.props;
 const { Content, headings, remarkPluginFrontmatter } = await post.render();

--- a/src/pages/notes/[...slug].astro
+++ b/src/pages/notes/[...slug].astro
@@ -9,6 +9,7 @@ import TableOfContents from "@components/TableOfContents.astro";
 import AstroImage from "@components/AstroImage.astro";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
+import { getAdjacentPosts } from "@lib/utils";
 dayjs.extend(utc);
 
 export async function getStaticPaths() {
@@ -24,28 +25,7 @@ type Props = CollectionEntry<"notes">;
 
 const posts = await getCollection("notes");
 
-function getNextPost() {
-  let postIndex;
-  for (const post of posts) {
-    if (post.slug === Astro.params.slug) {
-      postIndex = posts.indexOf(post);
-      return posts[postIndex + 1];
-    }
-  }
-}
-
-function getPrevPost() {
-  let postIndex;
-  for (const post of posts) {
-    if (post.slug === Astro.params.slug) {
-      postIndex = posts.indexOf(post);
-      return posts[postIndex - 1];
-    }
-  }
-}
-
-const nextPost = getNextPost();
-const prevPost = getPrevPost();
+const { nextPost, prevPost } = getAdjacentPosts(posts, Astro.params.slug);
 
 const post = Astro.props;
 const { Content, headings, remarkPluginFrontmatter } = await post.render();

--- a/src/pages/offers/expired.astro
+++ b/src/pages/offers/expired.astro
@@ -147,7 +147,7 @@ const pageDescription = campaignTitle
             
             <div class="contact-method">
               <h3>WhatsApp</h3>
-              <a href="https://wa.me/919999999999" target="_blank" rel="noopener">
+              <a href="https://wa.me/919999999999" target="_blank" rel="noopener noreferrer">
                 Chat on WhatsApp
               </a>
             </div>

--- a/src/pages/saasguide/[...slug].astro
+++ b/src/pages/saasguide/[...slug].astro
@@ -9,6 +9,7 @@ import TableOfContents from "@components/TableOfContents.astro";
 import AstroImage from "@components/AstroImage.astro";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
+import { getAdjacentPosts } from "@lib/utils";
 dayjs.extend(utc);
 
 export async function getStaticPaths() {
@@ -25,28 +26,7 @@ type Props = CollectionEntry<"saasguide">;
 
 const posts = await getCollection("saasguide");
 
-function getNextPost() {
-  let postIndex;
-  for (const post of posts) {
-    if (post.slug === Astro.params.slug) {
-      postIndex = posts.indexOf(post);
-      return posts[postIndex + 1];
-    }
-  }
-}
-
-function getPrevPost() {
-  let postIndex;
-  for (const post of posts) {
-    if (post.slug === Astro.params.slug) {
-      postIndex = posts.indexOf(post);
-      return posts[postIndex - 1];
-    }
-  }
-}
-
-const nextPost = getNextPost();
-const prevPost = getPrevPost();
+const { nextPost, prevPost } = getAdjacentPosts(posts, Astro.params.slug);
 
 const post = Astro.props;
 const { Content, headings, remarkPluginFrontmatter } = await post.render();

--- a/src/pages/works/[...slug].astro
+++ b/src/pages/works/[...slug].astro
@@ -9,6 +9,7 @@ import TableOfContents from "@components/TableOfContents.astro";
 import AstroImage from "@components/AstroImage.astro";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
+import { getAdjacentPosts } from "@lib/utils";
 dayjs.extend(utc);
 
 export async function getStaticPaths() {
@@ -24,28 +25,7 @@ type Props = CollectionEntry<"works">;
 
 const posts = await getCollection("works");
 
-function getNextPost() {
-  let postIndex;
-  for (const post of posts) {
-    if (post.slug === Astro.params.slug) {
-      postIndex = posts.indexOf(post);
-      return posts[postIndex + 1];
-    }
-  }
-}
-
-function getPrevPost() {
-  let postIndex;
-  for (const post of posts) {
-    if (post.slug === Astro.params.slug) {
-      postIndex = posts.indexOf(post);
-      return posts[postIndex - 1];
-    }
-  }
-}
-
-const nextPost = getNextPost();
-const prevPost = getPrevPost();
+const { nextPost, prevPost } = getAdjacentPosts(posts, Astro.params.slug);
 
 const post = Astro.props;
 const { Content, headings, remarkPluginFrontmatter } = await post.render();


### PR DESCRIPTION
🎯 **What:** Extracted duplicated `getNextPost` and `getPrevPost` logic into a single, reusable utility function `getAdjacentPosts` in `src/lib/utils.ts`. Refactored multiple Astro pages to use this new utility.

💡 **Why:** The previous implementation duplicated identical logic across six different file types (`articles`, `bibliophilediaries`, `faqs`, `notes`, `saasguide`, `works`). Centralizing this improves maintainability, reduces code duplication, and makes the codebase cleaner. Additionally, the new implementation uses `.findIndex()` which is more efficient than the previous `.indexOf()` within a loop.

✅ **Verification:** 
- Added utility function and verified correct placement in `src/lib/utils.ts`.
- Verified successful application of refactoring via `git diff`.
- Ran `npx astro check` to ensure no new regressions were introduced (pre-existing type errors remain unchanged).
- Successfully passed automated code review confirming correctness and safety of the implementation.

✨ **Result:** Reduced duplicate code footprint and provided a single source of truth for adjacent post calculation, significantly improving code health.

---
*PR created automatically by Jules for task [813534004439792162](https://jules.google.com/task/813534004439792162) started by @theWhiteWulfy*