### PR TITLE
🧹 [Code Health] Refactor duplicated getNext/PrevPost into a common utility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6774,9 +6774,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001727",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001727.tgz",
-            "integrity": "sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q==",
+            "version": "1.0.30001797",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001797.tgz",
+            "integrity": "sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w==",
             "funding": [
                 {
                     "type": "opencollective",

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -14,3 +14,17 @@ export function readingTime(html: string) {
   const readingTimeMinutes = (wordCount / 180 + 1).toFixed(); // 180 words per minute
   return `${readingTimeMinutes} min read`;
 }
+
+export function getAdjacentPosts<T extends { slug: string }>(
+  posts: T[],
+  currentSlug: string | undefined
+) {
+  const postIndex = posts.findIndex((post) => post.slug === currentSlug);
+  if (postIndex === -1) {
+    return { nextPost: undefined, prevPost: undefined };
+  }
+  return {
+    nextPost: posts[postIndex + 1],
+    prevPost: posts[postIndex - 1],
+  };
+}

--- a/src/pages/articles/[...slug].astro
+++ b/src/pages/articles/[...slug].astro
@@ -9,6 +9,7 @@ import TableOfContents from "@components/TableOfContents.astro";
 import AstroImage from "@components/AstroImage.astro";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
+import { getAdjacentPosts } from "@lib/utils";
 dayjs.extend(utc);
 
 export async function getStaticPaths() {
@@ -24,28 +25,7 @@ type Props = CollectionEntry<"articles">;
 
 const posts = await getCollection("articles");
 
-function getNextPost() {
-  let postIndex;
-  for (const post of posts) {
-    if (post.slug === Astro.params.slug) {
-      postIndex = posts.indexOf(post);
-      return posts[postIndex + 1];
-    }
-  }
-}
-
-function getPrevPost() {
-  let postIndex;
-  for (const post of posts) {
-    if (post.slug === Astro.params.slug) {
-      postIndex = posts.indexOf(post);
-      return posts[postIndex - 1];
-    }
-  }
-}
-
-const nextPost = getNextPost();
-const prevPost = getPrevPost();
+const { nextPost, prevPost } = getAdjacentPosts(posts, Astro.params.slug);
 
 const post = Astro.props;
 const { Content, headings, remarkPluginFrontmatter } = await post.render();

--- a/src/pages/bibliophilediaries/[...slug].astro
+++ b/src/pages/bibliophilediaries/[...slug].astro
@@ -9,6 +9,7 @@ import TableOfContents from "@components/TableOfContents.astro";
 import AstroImage from "@components/AstroImage.astro";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
+import { getAdjacentPosts } from "@lib/utils";
 dayjs.extend(utc);
 
 export async function getStaticPaths() {
@@ -24,28 +25,7 @@ type Props = CollectionEntry<"bibliophilediaries">;
 
 const posts = await getCollection("bibliophilediaries");
 
-function getNextPost() {
-  let postIndex;
-  for (const post of posts) {
-    if (post.slug === Astro.params.slug) {
-      postIndex = posts.indexOf(post);
-      return posts[postIndex + 1];
-    }
-  }
-}
-
-function getPrevPost() {
-  let postIndex;
-  for (const post of posts) {
-    if (post.slug === Astro.params.slug) {
-      postIndex = posts.indexOf(post);
-      return posts[postIndex - 1];
-    }
-  }
-}
-
-const nextPost = getNextPost();
-const prevPost = getPrevPost();
+const { nextPost, prevPost } = getAdjacentPosts(posts, Astro.params.slug);
 
 const post = Astro.props;
 const { Content, headings, remarkPluginFrontmatter } = await post.render();

--- a/src/pages/faqs/[...slug].astro
+++ b/src/pages/faqs/[...slug].astro
@@ -10,6 +10,7 @@ import AstroImage from "@components/AstroImage.astro";
 import type { FAQData } from "@lib/schema-generators";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
+import { getAdjacentPosts } from "@lib/utils";
 dayjs.extend(utc);
 
 export async function getStaticPaths() {
@@ -25,28 +26,7 @@ type Props = CollectionEntry<"faqs">;
 
 const posts = await getCollection("faqs");
 
-function getNextPost() {
-  let postIndex;
-  for (const post of posts) {
-    if (post.slug === Astro.params.slug) {
-      postIndex = posts.indexOf(post);
-      return posts[postIndex + 1];
-    }
-  }
-}
-
-function getPrevPost() {
-  let postIndex;
-  for (const post of posts) {
-    if (post.slug === Astro.params.slug) {
-      postIndex = posts.indexOf(post);
-      return posts[postIndex - 1];
-    }
-  }
-}
-
-const nextPost = getNextPost();
-const prevPost = getPrevPost();
+const { nextPost, prevPost } = getAdjacentPosts(posts, Astro.params.slug);
 
 const post = Astro.props;
 const { Content, headings, remarkPluginFrontmatter } = await post.render();

--- a/src/pages/notes/[...slug].astro
+++ b/src/pages/notes/[...slug].astro
@@ -9,6 +9,7 @@ import TableOfContents from "@components/TableOfContents.astro";
 import AstroImage from "@components/AstroImage.astro";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
+import { getAdjacentPosts } from "@lib/utils";
 dayjs.extend(utc);
 
 export async function getStaticPaths() {
@@ -24,28 +25,7 @@ type Props = CollectionEntry<"notes">;
 
 const posts = await getCollection("notes");
 
-function getNextPost() {
-  let postIndex;
-  for (const post of posts) {
-    if (post.slug === Astro.params.slug) {
-      postIndex = posts.indexOf(post);
-      return posts[postIndex + 1];
-    }
-  }
-}
-
-function getPrevPost() {
-  let postIndex;
-  for (const post of posts) {
-    if (post.slug === Astro.params.slug) {
-      postIndex = posts.indexOf(post);
-      return posts[postIndex - 1];
-    }
-  }
-}
-
-const nextPost = getNextPost();
-const prevPost = getPrevPost();
+const { nextPost, prevPost } = getAdjacentPosts(posts, Astro.params.slug);
 
 const post = Astro.props;
 const { Content, headings, remarkPluginFrontmatter } = await post.render();

--- a/src/pages/saasguide/[...slug].astro
+++ b/src/pages/saasguide/[...slug].astro
@@ -9,6 +9,7 @@ import TableOfContents from "@components/TableOfContents.astro";
 import AstroImage from "@components/AstroImage.astro";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
+import { getAdjacentPosts } from "@lib/utils";
 dayjs.extend(utc);
 
 export async function getStaticPaths() {
@@ -25,28 +26,7 @@ type Props = CollectionEntry<"saasguide">;
 
 const posts = await getCollection("saasguide");
 
-function getNextPost() {
-  let postIndex;
-  for (const post of posts) {
-    if (post.slug === Astro.params.slug) {
-      postIndex = posts.indexOf(post);
-      return posts[postIndex + 1];
-    }
-  }
-}
-
-function getPrevPost() {
-  let postIndex;
-  for (const post of posts) {
-    if (post.slug === Astro.params.slug) {
-      postIndex = posts.indexOf(post);
-      return posts[postIndex - 1];
-    }
-  }
-}
-
-const nextPost = getNextPost();
-const prevPost = getPrevPost();
+const { nextPost, prevPost } = getAdjacentPosts(posts, Astro.params.slug);
 
 const post = Astro.props;
 const { Content, headings, remarkPluginFrontmatter } = await post.render();

--- a/src/pages/works/[...slug].astro
+++ b/src/pages/works/[...slug].astro
@@ -9,6 +9,7 @@ import TableOfContents from "@components/TableOfContents.astro";
 import AstroImage from "@components/AstroImage.astro";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
+import { getAdjacentPosts } from "@lib/utils";
 dayjs.extend(utc);
 
 export async function getStaticPaths() {
@@ -24,28 +25,7 @@ type Props = CollectionEntry<"works">;
 
 const posts = await getCollection("works");
 
-function getNextPost() {
-  let postIndex;
-  for (const post of posts) {
-    if (post.slug === Astro.params.slug) {
-      postIndex = posts.indexOf(post);
-      return posts[postIndex + 1];
-    }
-  }
-}
-
-function getPrevPost() {
-  let postIndex;
-  for (const post of posts) {
-    if (post.slug === Astro.params.slug) {
-      postIndex = posts.indexOf(post);
-      return posts[postIndex - 1];
-    }
-  }
-}
-
-const nextPost = getNextPost();
-const prevPost = getPrevPost();
+const { nextPost, prevPost } = getAdjacentPosts(posts, Astro.params.slug);
 
 const post = Astro.props;
 const { Content, headings, remarkPluginFrontmatter } = await post.render();


### PR DESCRIPTION
🎯 **What:** Extracted duplicated `getNextPost` and `getPrevPost` functions across multiple Astro collection pages into a single utility function `getAdjacentPosts` inside `src/lib/utils.ts`.
💡 **Why:** The original code had the exact same block of logic copy-pasted across 6 files, which bloated the pages and increased the maintenance burden if the underlying collection logic changed. Consolidating it improves code health and readability.
✅ **Verification:** Re-ran `npm run build` which runs the Astro type-checker (`astro check`). The new generic utility correctly matches types. No regression or build failures were introduced for the modified files.
✨ **Result:** Cleaned up about 20 lines of redundant code per file, leading to significantly leaner, more maintainable page layouts.

---
*PR created automatically by Jules for task [13306523990397699704](https://jules.google.com/task/13306523990397699704) started by @theWhiteWulfy*