### PR TITLE
🔒 Security Fix: Prevent Reverse Tabnabbing on External Links

### DIFF
--- a/src/components/CampaignCTA.astro
+++ b/src/components/CampaignCTA.astro
@@ -231,7 +231,7 @@ const formId = `campaign-form-${campaignSlug}`;
             <p class="privacy-note">
               <span class="privacy-icon">🔒</span>
               Your information is secure and will never be shared.
-              <a href="/terms/" target="_blank">Privacy Policy</a>
+              <a href="/terms/" target="_blank" rel="noopener noreferrer">Privacy Policy</a>
             </p>
 
             {

--- a/src/pages/offers/expired.astro
+++ b/src/pages/offers/expired.astro
@@ -147,7 +147,7 @@ const pageDescription = campaignTitle
             
             <div class="contact-method">
               <h3>WhatsApp</h3>
-              <a href="https://wa.me/919999999999" target="_blank" rel="noopener">
+              <a href="https://wa.me/919999999999" target="_blank" rel="noopener noreferrer">
                 Chat on WhatsApp
               </a>
             </div>


### PR DESCRIPTION
🎯 **What:** Missing `rel="noopener noreferrer"` attribute on external links with `target="_blank"`
⚠️ **Risk:** Reverse tabnabbing vulnerability where a newly opened tab can manipulate the original tab's location via `window.opener`
🛡️ **Solution:** Added `rel="noopener noreferrer"` attribute to the "Privacy Policy" link in `CampaignCTA.astro` and upgraded the `rel="noopener"` attribute to `rel="noopener noreferrer"` on the WhatsApp link in `expired.astro`

---
*PR created automatically by Jules for task [16454840957396241772](https://jules.google.com/task/16454840957396241772) started by @theWhiteWulfy*