### PR TITLE
Fix lightbox image size on window resize

### DIFF
--- a/src/pages/illustrations/[...id].astro
+++ b/src/pages/illustrations/[...id].astro
@@ -112,12 +112,13 @@ const images = await getAlbumImages(album.id);
       }
   });
 
-  // TODO: taken window resize into account
-  // window.addEventListener('resize', (e) => {
-
-  // });
-
-  // console.log({ lbTriggers });
+  window.addEventListener('resize', () => {
+      const img = portal.querySelector("img");
+      if (img) {
+          const ratio = img.naturalWidth / img.naturalHeight;
+          img.sizes = `${window.innerHeight * ratio}px`;
+      }
+  });
 </script>
 
 <style>


### PR DESCRIPTION
Update the lightbox sizing logic to dynamically adjust the image's `sizes` attribute when the `window` resize event is triggered, ensuring the image scales appropriately according to `window.innerHeight`.

---
*PR created automatically by Jules for task [17731182309117626444](https://jules.google.com/task/17731182309117626444) started by @theWhiteWulfy*